### PR TITLE
Functionality to walk over file systems

### DIFF
--- a/ReleaseNotes.adoc
+++ b/ReleaseNotes.adoc
@@ -5,7 +5,8 @@ of the CloudFiles library.
 
 == Release 0.9 (TBD)
 
-The traits for file system elements in the `Model` class of the _core_ module have now covariance annotations.
+* The traits for file system elements in the `Model` class of the _core_ module have now covariance annotations.
+* Support for Scala 2.12.x has been dropped. The project is now cross-compiled against Scala 2.13.16 and 3.3.5.
 
 == Release 0.8 (2024-10-15)
 

--- a/ReleaseNotes.adoc
+++ b/ReleaseNotes.adoc
@@ -7,6 +7,7 @@ of the CloudFiles library.
 
 * The traits for file system elements in the `Model` class of the _core_ module have now covariance annotations.
 * Support for Scala 2.12.x has been dropped. The project is now cross-compiled against Scala 2.13.16 and 3.3.5.
+* Added the `Walk` object to the _core_ module to support convenient iteration over folder structures.
 
 == Release 0.8 (2024-10-15)
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ lazy val CloudFilesVersion = "0.9-SNAPSHOT"
 
 /** Supported Scala versions. */
 lazy val VersionScala213 = "2.13.16"
-lazy val VersionScala212 = "2.12.20"
 lazy val VersionScala3 = "3.3.5"
 
 /** Versions of compile-time dependencies. */
@@ -35,7 +34,7 @@ lazy val VersionScalaTestMockito = "3.2.19.0"
 lazy val VersionScalaXml = "2.2.0"
 lazy val VersionWireMock = "3.12.1"
 
-lazy val supportedScalaVersions = List(VersionScala213, VersionScala212, VersionScala3)
+lazy val supportedScalaVersions = List(VersionScala213, VersionScala3)
 
 lazy val ITest = config("integrationTest") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,9 @@ import com.github.sbt.osgi.OsgiKeys
 lazy val CloudFilesVersion = "0.9-SNAPSHOT"
 
 /** Supported Scala versions. */
-lazy val VersionScala213 = "2.13.15"
+lazy val VersionScala213 = "2.13.16"
 lazy val VersionScala212 = "2.12.20"
-lazy val VersionScala3 = "3.3.4"
+lazy val VersionScala3 = "3.3.5"
 
 /** Versions of compile-time dependencies. */
 lazy val VersionPekko = "1.1.3"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -25,15 +25,15 @@ lazy val VersionScala212 = "2.12.20"
 lazy val VersionScala3 = "3.3.4"
 
 /** Versions of compile-time dependencies. */
-lazy val VersionPekko = "1.1.2"
+lazy val VersionPekko = "1.1.3"
 lazy val VersionPekkoHttp = "1.1.0"
-lazy val VersionSlf4j = "2.0.16"
+lazy val VersionSlf4j = "2.0.17"
 
 /** Versions of test dependencies. */
 lazy val VersionScalaTest = "3.2.19"
 lazy val VersionScalaTestMockito = "3.2.19.0"
 lazy val VersionScalaXml = "2.2.0"
-lazy val VersionWireMock = "3.9.1"
+lazy val VersionWireMock = "3.12.1"
 
 lazy val supportedScalaVersions = List(VersionScala213, VersionScala212, VersionScala3)
 

--- a/core/README.adoc
+++ b/core/README.adoc
@@ -235,7 +235,53 @@ val source = Walk.dfsSource(
   rootPath,
   transformFunc
 )
-val sink = Sink.fold[List[Model.Element[Path]], Model.Element[Path]](start)((lst, p) => p :: lst)
+val sink = Sink.fold[List[Model.Element[Path]], Model.Element[Path]](List.empty)((lst, p) => p :: lst)
 
 val futElements = source.runWith(sink)
 ----
+
+In some cases, client code is not only interested in the elements found in the folder structure themselves but also requires information about the concrete position of these elements in the hierarchy - something like the _path_ from a concrete element to the root folder of the iteration.
+
+This is supported by another set of functions ending on the suffix `WithParentData`. The stream source these functions return does not yield simple elements, but objects of the data class `ElementWithParentData`. The data class stores the actual element plus a list of customizable data collected from the parent folders of this element on the way down the hierarchy. The first element in this list is obtained from the direct parent folder of the element; the next element comes from the parent folder of this folder, and so on.
+
+To specify, which data to extract from parent folders, the `WithParentData` functions accept a function of the following type:
+
+[source, scala]
+----
+type ParentDataFunc[ID, DATA] = Model.Folder[ID] => Option[DATA]
+----
+
+The function is passed a (parent) folder element. It returns an `Option` with the data to store for this folder. In case of a _None_ result, no data is stored in the parent data list for this folder.
+
+As an example, consider the use case that for each element found in the folder structure a path string in the form "grandParent / parent / element" should be generated. So, the function to extract parent data just needs to return the name of the passed in folder. An implementation could look as follows (again we are using the local file system for illustration purpose):
+
+[source, scala]
+----
+val fsOptions = LocalFsConfig(
+  basePath = Paths.get("/data"),
+  executionContext = ExecutionContext.global
+)
+val fileSystem = new LocalFileSystem(fsOptions)
+val rootPath = Paths.get("/data/processing")
+
+val parentDataFunc: ParentDataFunc[Path, String] =
+  folder => Some(folder.name)
+
+val source = Walk.dfsSourceWithParentData(
+  fileSystem,
+  null, // No HTTP actor needed for local FS.
+  rootPath,
+  parentDataFunc
+).map { elemWithParent =>
+  val path = elemWithParent.parentData.reverse
+    .mkString(" / ")
+  (path, elementWithParent.element)
+}
+val sink = Sink.fold[List[(String, Model.Element[Path])], (String, Model.Element[Path])](List.empty) {
+  (lst, p) => p :: lst
+}
+
+val futElements = source.runWith(sink)
+----
+
+The stream now yields tuples consisting of the path string and the found elements. Note that the `WithParentData` functions support a transformation function as well; so it is possible to customize the iteration as described above.

--- a/core/README.adoc
+++ b/core/README.adoc
@@ -95,6 +95,7 @@ The factory for request actors needs a way to create new actor instances. How th
 == File systems
 The basic abstraction introduced by CloudFiles is represented by the link:src/main/scala/com/github/cloudfiles/core/FileSystem.scala[FileSystem] trait. A `FileSystem` object can be used to execute typical CRUD operations on files and directories on a server that supports a specific protocol. The various submodules of CloudFiles typically provide specialized `FileSystem` implementations that support a specific protocol. Refer to the README documents of these modules for further details.
 
+[#type_parameters]
 === Type parameters
 The `FileSystem` trait has a number of type parameters:
 
@@ -176,3 +177,65 @@ To make advanced transformations possible, as required by the use cases listed a
 To simplify the implementation of concrete extensions, CloudFiles has the link:src/main/scala/com/github/cloudfiles/core/delegate/DelegateFileSystem.scala[DelegateFileSystem] trait. It provides default implementations for all the operations defined by `FileSystem` that just forward the call to another `FileSystem` object. So, an extension implementation extending this trait just needs to override the methods affected by the specific functionality it provides and can use the default implementations for all others.
 
 To sum up, CloudFiles' file systems can be grouped into two categories: file systems that implement the `FileSystem` API for a specific protocol, and file systems implementing extended functionality on arbitrary other file systems.
+
+=== Further functionality
+Around the `FileSystem` abstraction, the _core_ module provides some helper functionality which is generally useful when dealing with files and folder structures. This can be used together with all concrete `FileSystem` implementations.
+
+==== Iterating over folder structures
+A frequent use case is to iterate over all files and folders located below a specific root folder, e.g. to find specific files or to apply some processing logic on the encountered elements. For this purpose, the _core_ module offers the link:src/main/scala/com/github/cloudfiles/core/utils/Walk.scala[Walk] object. The general idea is that a client provides a `FileSystem` instance, an HTTP actor to execute requests against this file system, and the ID of a start folder. There are functions to iterate over the content of the start folder in different orders, namely https://en.wikipedia.org/wiki/Breadth-first_search[Breadth-first search], and https://en.wikipedia.org/wiki/Depth-first_search[Depth-first search]. The functions return a `Source` of an https://pekko.apache.org/[Apache Pekko] stream with the encountered elements. Via the means offered by https://pekko.apache.org/docs/pekko/current/stream/index.html[Apache Pekko Streams], sophisticated processing is possible on the elements in the folder structure.
+
+Below is a simple example how a folder structure can be processed in breadth-first search order to simply collect all elements:
+
+[source, scala]
+----
+val fileSystem = ... // Obtain the file system.
+val httpActor = ... // Obtain the actor for sending requests.
+val rootFolderID = ... // The folder to iterate over.
+
+val walkSource = Walk.bfsSearch(fileSystem, httpActor, rootFolderID)
+val start = List.empty[Model.Element[ID]]
+val sink = Sink.fold[List[Model.Element[ID]], Model.Element[ID]](start)((lst, p) => p :: lst)
+
+val futElements = walkSource.runWith(sink)
+futElements.map { elements =>
+  // elements is a List[Model.Element[ID]]
+}
+----
+
+The <<type_parameters>> associated with the file system are also reflected by the `Walk` object, which makes its usage a bit complicated. To make a generic iteration possible, the `FILE`, `FOLDER`, and `FOLDER_CONTENT` parameters of the file system must extend the base traits from link:src/main/scala/com/github/cloudfiles/core/Model.scala[Model].
+
+There is sometimes the need to further customize the iteration, e.g. to filter out specific elements or to apply a defined sort order. It is possible to do this with operators provided by https://pekko.apache.org/docs/pekko/current/stream/index.html[Apache Pekko Streams], but it may be more efficient to handle such customization already in the source itself. This is certainly the case if larger parts of the folder structured iterated over can be filtered out, so that they do not have to be processed at first. To achieve this, the functions of `Walk` accept another optional parameter, a so-called _transformation function_. The function type is defined as follows:
+
+[source, scala]
+----
+type TransformFunc[ID] = List[Model.Element[ID]] => List[Model.Element[ID]]
+----
+
+Basically, the function maps a list of folder elements (which can be files and subfolders) to another list. `Walk` invokes this function during the iteration for each new folder to be processed and then iterates over the resulting list of elements. That way, clients can do arbitrary manipulations on the list before it gets processed.
+
+To give a concrete example of this functionality, the use case to filter out "*.tmp" files and to sort elements by their names is to be implemented. To simplify dealing with the file system's type parameters, we use the link:../localfs/README.adoc[Local FileSystem] implementation, which uses the type `java.nio.Path` as ID for elements:
+
+[source, scala]
+----
+val fsOptions = LocalFsConfig(
+  basePath = Paths.get("/data"),
+  executionContext = ExecutionContext.global
+)
+val fileSystem = new LocalFileSystem(fsOptions)
+val rootPath = Paths.get("/data/processing")
+
+val transformFunc: TransformFunc[Path] = elements =>
+  elements.filterNot { element =>
+    element.name.endsWith(".tmp")
+  }.sortWith((e1, e2) => e1.name < e2.name)
+
+val source = Walk.dfsSource(
+  fileSystem,
+  null, // No HTTP actor needed for local FS.
+  rootPath,
+  transformFunc
+)
+val sink = Sink.fold[List[Model.Element[Path]], Model.Element[Path]](start)((lst, p) => p :: lst)
+
+val futElements = source.runWith(sink)
+----

--- a/core/src/main/scala/com/github/cloudfiles/core/FileSystem.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/FileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/Model.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/Model.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/delegate/DelegateFileSystem.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/delegate/DelegateFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/delegate/ElementPatchSpec.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/delegate/ElementPatchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/delegate/ExtensibleFileSystem.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/delegate/ExtensibleFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/HttpRequestSender.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/HttpRequestSender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/MultiHostExtension.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/MultiHostExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/ProxySupport.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/ProxySupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/RequestQueue.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/RequestQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/RetryAfterExtension.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/RetryAfterExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/Secret.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/Secret.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/UriEncodingHelper.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/UriEncodingHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/auth/AuthConfig.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/auth/AuthConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/auth/AuthExtension.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/auth/AuthExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/auth/BasicAuthExtension.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/auth/BasicAuthExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/auth/OAuthExtension.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/auth/OAuthExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/auth/OAuthTokenData.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/auth/OAuthTokenData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderConfig.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderFactory.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderFactoryImpl.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderFactoryImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/factory/Spawner.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/factory/Spawner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/utils/LRUCache.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/utils/LRUCache.scala
@@ -117,9 +117,8 @@ class LRUCache[K, +V] private(val capacity: Int,
         val index = maps._3 + 1
         val optOldValue = maps._1 get e._1
         val nextEntries = maps._1 + (e._1 -> CacheEntry(e._2, index))
-        // Note: The "+" function is deprecated in Scala 2.13, but the recommended concat() is unavailable in 2.12.
         val nextLru = optOldValue.map(ce => removeKey(maps._2, ce.index))
-          .getOrElse(maps._2) + (index -> e._1)
+          .getOrElse(maps._2).concat(List(index -> e._1))
         (nextEntries, nextLru, index)
       }
 

--- a/core/src/main/scala/com/github/cloudfiles/core/utils/LRUCache.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/utils/LRUCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/github/cloudfiles/core/utils/Walk.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/utils/Walk.scala
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2020-2025 The Developers Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.cloudfiles.core.utils
+
+import com.github.cloudfiles.core.http.HttpRequestSender
+import com.github.cloudfiles.core.{FileSystem, Model}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.typed.{ActorRef, ActorSystem}
+import org.apache.pekko.stream.{Attributes, Outlet, SourceShape}
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * A module providing functionality to iterate over a folder structure in a
+ * [[FileSystem]].
+ *
+ * This module offers functions supporting walk functionality in different
+ * orders. The functions expect the [[FileSystem]] to iterate over, the HTTP
+ * actor to interact with the file system, and the ID of the root folder. They
+ * return a [[Source]] with [[Model.Element]] objects for the items that where
+ * encountered in this folder structure.
+ */
+object Walk {
+  /**
+   * The size of a chunk when resolving the contents of folders during the
+   * iteration.
+   */
+  private val ResolveFoldersChunkSize = 8
+
+  /**
+   * Returns a [[Source]] to iterate over a folder structure in breadth-first
+   * search order.
+   *
+   * @param fileSystem the [[FileSystem]] that is the target of the iteration
+   * @param httpActor  the actor for sending HTTP requests
+   * @param rootID     the ID of the root folder of the iteration
+   * @param system     the actor system
+   * @tparam ID     the type of element IDs
+   * @tparam FILE   the type for files
+   * @tparam FOLDER the type for folders
+   * @return the [[Source]] with the encountered elements
+   */
+  def bfsSource[ID, FILE <: Model.File[ID],
+    FOLDER <: Model.Folder[ID]](fileSystem: FileSystem[ID, FILE, FOLDER, Model.FolderContent[ID, FILE, FOLDER]],
+                                httpActor: ActorRef[HttpRequestSender.HttpCommand],
+                                rootID: ID)
+                               (implicit system: ActorSystem[_]): Source[Model.Element[ID], NotUsed] = {
+    val walkSource = new WalkSource(fileSystem, httpActor, rootID) {
+      override type WalkState = BfsState[ID, FILE, FOLDER]
+
+      override protected val walkFunc: WalkFunc[ID, FILE, FOLDER, WalkState] = walkBfs
+
+      override protected def initialState: WalkState = BfsState(List.empty, Queue.empty)
+    }
+
+    Source.fromGraph(walkSource)
+  }
+
+  /**
+   * Definition of a function that controls the iteration over the folder 
+   * structure. The function operates on a specific state that is managed by 
+   * the source implementation. It is passed such a state object and a list
+   * with [[Model.FolderContent]] objects that have been resolved from the
+   * file system. It returns an [[Option]] that is ''None'' at the end of the
+   * iteration. Otherwise, it contains a tuple with the updated state, an
+   * [[Option]] with the next element to pass downstream, and a list with the
+   * IDs of folders whose content is needed.
+   */
+  private type WalkFunc[ID, FILE <: Model.File[ID], FOLDER <: Model.Folder[ID], STATE] =
+    (STATE, Iterable[Model.FolderContent[ID, FILE, FOLDER]]) => Option[(STATE, Option[Model.Element[ID]], List[ID])]
+
+  /**
+   * A data class holding the state of an iteration in BFS order.
+   *
+   * @param currentFolderElements the elements from the current
+   * @param foldersToProcess      the content of folders to be processed next
+   * @tparam ID     the type of IDs of elements
+   * @tparam FILE   the type of files
+   * @tparam FOLDER the type of folders
+   */
+  private case class BfsState[ID, FILE <: Model.File[ID],
+    FOLDER <: Model.Folder[ID]](currentFolderElements: List[Model.Element[ID]],
+                                foldersToProcess: Queue[Model.FolderContent[ID, FILE, FOLDER]])
+
+  /**
+   * Implementation of a [[Source]] that produces the data of a walk operation
+   * with the help of a [[WalkFunc]] that determines the order in which the
+   * folder structure is processed.
+   *
+   * @param fileSystem the [[FileSystem]] that is the target of the iteration
+   * @param httpActor  the actor for sending HTTP requests
+   * @param rootID     the ID of the root folder of the iteration
+   * @param system     the actor system
+   * @tparam ID     the type of element IDs
+   * @tparam FILE   the type for files
+   * @tparam FOLDER the type for folders
+   */
+  private abstract class WalkSource[ID, FILE <: Model.File[ID],
+    FOLDER <: Model.Folder[ID]](fileSystem: FileSystem[ID, FILE, FOLDER, Model.FolderContent[ID, FILE, FOLDER]],
+                                httpActor: ActorRef[HttpRequestSender.HttpCommand],
+                                rootID: ID)
+                               (implicit system: ActorSystem[_])
+    extends GraphStage[SourceShape[Model.Element[ID]]] {
+    /** Type definition for the specific state of the iteration. */
+    type WalkState
+
+    private val out: Outlet[Model.Element[ID]] = Outlet("WalkSource")
+
+    override def shape: SourceShape[Model.Element[ID]] = SourceShape(out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) {
+        /** Callback for the asynchronous operation to load folder contents. */
+        private val resolvedFoldersCallback = getAsyncCallback(onFoldersResolved)
+
+        /** The current state of the iteration. */
+        private var currentState = initialState
+
+        /**
+         * Stores the ID of folders for which the content has to be fetched.
+         * This is done in chunks.
+         */
+        private var foldersToResolve = Vector(rootID)
+
+        /**
+         * Stores already resolved folder content objects. They are passed to
+         * the iteration function the next time data is to be fetched.
+         */
+        private var resolvedFolders = Vector.empty[Model.FolderContent[ID, FILE, FOLDER]]
+
+        /**
+         * A flag whether currently the content of folders is resolved.
+         */
+        private var resolveInProgress = false
+
+        /** Flag whether downstream has pulled for data. */
+        private var pulled = false
+
+        setHandler(out, new OutHandler {
+          override def onPull(): Unit = {
+            pulled = true
+            continueWalking()
+          }
+        })
+
+        override def preStart(): Unit = {
+          loadFolderContent()
+        }
+
+        /**
+         * Processes a chunk of folders that need to be resolved and calls the
+         * file system to load their contents.
+         *
+         * @return '''true''' if folders are pending to be loaded; '''false'''
+         *         otherwise
+         */
+        private def loadFolderContent(): Boolean = {
+          if (foldersToResolve.nonEmpty) {
+            implicit val ec: ExecutionContext = system.executionContext
+            Future.sequence(foldersToResolve.take(ResolveFoldersChunkSize)
+              .map { folderID =>
+                val operation = fileSystem.folderContent(folderID)
+                operation.run(httpActor)
+              }).foreach(resolvedFoldersCallback.invoke)
+            resolveInProgress = true
+            foldersToResolve = foldersToResolve.drop(ResolveFoldersChunkSize)
+            true
+          } else false
+        }
+
+        /**
+         * Handles a result of a resolve operation on folders. Stores the
+         * folder contents and continues with the iteration if possible.
+         *
+         * @param contents the resolved folder contents
+         */
+        private def onFoldersResolved(contents: Vector[Model.FolderContent[ID, FILE, FOLDER]]): Unit = {
+          resolveInProgress = false
+          resolvedFolders = contents
+          continueWalking()
+        }
+
+        /**
+         * Checks whether currently data is available that can be pushed
+         * downstream by invoking the walk function. All necessary steps are
+         * done to continue with the iteration.
+         */
+        @tailrec private def continueWalking(): Unit = {
+          if (pulled && !resolveInProgress) {
+            val actionTaken = walkFunc(currentState, resolvedFolders) match {
+              case Some((nextState, optData, folderIDs)) =>
+                currentState = nextState
+                foldersToResolve = foldersToResolve :++ folderIDs
+                optData match {
+                  case Some(data) =>
+                    push(out, data)
+                    pulled = false
+                    loadFolderContent()
+                    true
+                  case None =>
+                    loadFolderContent()
+                }
+
+              case None =>
+                completeStage()
+                true
+            }
+
+            resolvedFolders = Vector.empty
+            if (!actionTaken) continueWalking()
+          }
+        }
+      }
+
+    /**
+     * Returns the function that controls the iteration. This function is 
+     * invoked repeatedly to obtain the elements to pass downstream.
+     */
+    protected val walkFunc: WalkFunc[ID, FILE, FOLDER, WalkState]
+
+    /**
+     * Returns the initial state for the iteration.
+     *
+     * @return the initial [[WalkState]]
+     */
+    protected def initialState: WalkState
+  }
+
+  /**
+   * A concrete [[WalkFunc]] for iterating over a folder structure in
+   * breadth-first search.
+   *
+   * @param state    the current walk state
+   * @param contents the contents of resolved folders
+   * @tparam ID     the type of element IDs
+   * @tparam FILE   the type for files
+   * @tparam FOLDER the type for folders
+   * @return information to continue the walk operation
+   */
+  private def walkBfs[ID, FILE <: Model.File[ID],
+    FOLDER <: Model.Folder[ID]](state: BfsState[ID, FILE, FOLDER],
+                                contents: Iterable[Model.FolderContent[ID, FILE, FOLDER]]):
+  Option[(BfsState[ID, FILE, FOLDER], Option[Model.Element[ID]], List[ID])] = {
+    val nextFolders = state.foldersToProcess.appendedAll(contents)
+
+    state.currentFolderElements match {
+      case h :: t =>
+        Some((BfsState(t, nextFolders), Some(h), Nil))
+
+      case _ =>
+        nextFolders.dequeueOption match {
+          case Some((folder, nextQueue)) =>
+            val subFolders = folder.folders.values.toList
+            val subFiles = folder.files.values.toList
+            val subFilesTail = if (subFiles.isEmpty) Nil else subFiles.tail
+            val nextElements = subFilesTail ::: subFolders
+            val nextState = BfsState(nextElements, nextQueue)
+            Some((nextState, subFiles.headOption, subFolders.map(_.id)))
+          case None =>
+            None
+        }
+    }
+  }
+}

--- a/core/src/test/scala/com/github/cloudfiles/core/FileSystemSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/FileSystemSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/FileTestHelper.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/FileTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/ModelSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/ModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/WireMockSupport.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/WireMockSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/delegate/DelegateFileSystemSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/delegate/DelegateFileSystemSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/HttpRequestSenderITSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/HttpRequestSenderITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/HttpRequestSenderSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/HttpRequestSenderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/MultiHostExtensionITSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/MultiHostExtensionITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/ProxyITSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/ProxyITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/ProxySupportSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/ProxySupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/RequestQueueSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/RequestQueueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/RetryAfterExtensionSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/RetryAfterExtensionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/SecretSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/SecretSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/UriEncodingHelperSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/UriEncodingHelperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/auth/BasicAuthExtensionSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/auth/BasicAuthExtensionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/auth/OAuthExtensionSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/auth/OAuthExtensionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/auth/OAuthExtensionSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/auth/OAuthExtensionSpec.scala
@@ -538,7 +538,8 @@ class OAuthExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpecLike 
       HttpRequestSender.FailedResult(request, FailedResponseException(httpResponseUnauthorized))
     val response2 = HttpRequestSender.SuccessResult(request, HttpResponse())
     val response3 = HttpRequestSender.SuccessResult(request, HttpResponse(status = StatusCodes.Accepted))
-    val stubRequests = List(StubData(createAuthorizedTestRequest(), responseUnauthorized),
+    val stubRequests = List(
+      StubData(createAuthorizedTestRequest(), responseUnauthorized, optDelay = Some(100.millis)),
       StubData(createAuthorizedTestRequest(), responseUnauthorized, optDelay = Some(100.millis)),
       StubData(createAuthorizedTestRequest(RefreshedTokens.accessToken), response2),
       StubData(createAuthorizedTestRequest(RefreshedTokens.accessToken), response3))

--- a/core/src/test/scala/com/github/cloudfiles/core/http/auth/OAuthTokenDataSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/auth/OAuthTokenDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderFactoryImplITSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderFactoryImplITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/factory/SpawnerClassicSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/factory/SpawnerClassicSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/factory/SpawnerTestActor.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/factory/SpawnerTestActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/http/factory/SpawnerTypedSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/factory/SpawnerTypedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/utils/LRUCacheSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/utils/LRUCacheSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/github/cloudfiles/core/utils/WalkSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/utils/WalkSpec.scala
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2020-2025 The Developers Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.cloudfiles.core.utils
+
+import com.github.cloudfiles.core.FileSystem.Operation
+import com.github.cloudfiles.core.{FileSystem, FileTestHelper, Model}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.typed.scaladsl.adapter._
+import org.apache.pekko.actor.{ActorSystem, typed}
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
+import org.scalatest.Inspectors.forAll
+import org.scalatest.flatspec.AsyncFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import java.io.File
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{Files, Path}
+import java.time.Instant
+import scala.annotation.tailrec
+import scala.concurrent.Future
+
+object WalkSpec {
+  /** Type alias for the elements in the iteration. */
+  type WalkItem = Model.Element[Path]
+
+  /** Type alias for files in the iteration. */
+  type WalkFile = Model.File[Path]
+
+  /** Type alias for folders in the iteration. */
+  type WalkFolder = Model.Folder[Path]
+
+  /** Type alias for folder content objects. */
+  type WalkFolderContent = Model.FolderContent[Path, WalkFile, WalkFolder]
+
+  /**
+   * Creates a file element in the iteration from the given file.
+   *
+   * @param file the file
+   * @return the corresponding file element
+   */
+  private def createFile(file: File): WalkFile = {
+    val path = file.toPath
+    val attributes = Files.readAttributes(path, classOf[BasicFileAttributes])
+    new WalkFile {
+      override def size: Long = file.length()
+
+      override def id: Path = path
+
+      override def name: String = file.getName
+
+      override def description: Option[String] = None
+
+      override def createdAt: Instant = attributes.creationTime().toInstant
+
+      override def lastModifiedAt: Instant = attributes.lastModifiedTime().toInstant
+    }
+  }
+
+  /**
+   * Creates a folder element in the iteration from the given file.
+   *
+   * @param folder the folder
+   * @return the corresponding folder element
+   */
+  private def createFolder(folder: File): WalkFolder = {
+    val path = folder.toPath
+    val attributes = Files.readAttributes(path, classOf[BasicFileAttributes])
+    new WalkFolder {
+      override def id: Path = path
+
+      override def name: String = folder.getName
+
+      override def description: Option[String] = None
+
+      override def createdAt: Instant = attributes.creationTime().toInstant
+
+      override def lastModifiedAt: Instant = attributes.lastModifiedTime().toInstant
+    }
+  }
+}
+
+/**
+ * Test class for [[Walk]].
+ *
+ * This class tests the generic walk functionality by using a local file
+ * system. Using this approach, it is quite easy to set up meaningful test
+ * data.
+ */
+class WalkSpec(testSystem: ActorSystem) extends TestKit(testSystem) with AsyncFlatSpecLike with BeforeAndAfterAll
+  with BeforeAndAfter with Matchers with FileTestHelper {
+  def this() = this(ActorSystem("WalkSpec"))
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  after {
+    tearDownTestFile()
+  }
+
+  import WalkSpec._
+
+  /** The typed actor system in implicit scope. */
+  private implicit val typedActorSystem: typed.ActorSystem[_] = system.toTyped
+
+  /**
+   * Creates a file with a given name in a given directory. The content of the
+   * file is its name as string.
+   *
+   * @param dir  the directory
+   * @param name the name of the file to be created
+   * @return the path to the newly created file
+   */
+  private def createFile(dir: Path, name: String): Path =
+    writeFileContent(dir resolve name, name)
+
+  /**
+   * Creates a directory below the given parent directory.
+   *
+   * @param parent the parent directory
+   * @param name   the name of the new directory
+   * @return the newly created directory
+   */
+  private def createDir(parent: Path, name: String): Path = {
+    val dir = parent.resolve(name)
+    Files.createDirectory(dir)
+    dir
+  }
+
+  /**
+   * Creates a directory structure with some test files and directories.
+   *
+   * @return a map with all directories and the files created in them
+   */
+  private def setUpDirectoryStructure(): Map[Path, Seq[Path]] = {
+    val rootFiles = List(createFile(testDirectory, "test.txt"),
+      createFile(testDirectory, "noMedium1.mp3"))
+    val dir1 = createDir(testDirectory, "medium1")
+    val dir2 = createDir(testDirectory, "medium2")
+    val dir1Files = List(
+      createFile(dir1, "noMedium2.mp3"),
+      createFile(dir1, "README.TXT"),
+      createFile(dir1, "medium1.settings"))
+    val sub1 = createDir(dir1, "aSub1")
+    val sub1Files = List(createFile(sub1, "medium1Song1.mp3"))
+    val sub1Sub = createDir(sub1, "subSub")
+    val sub1SubFiles = List(
+      createFile(sub1Sub, "medium1Song2.mp3"),
+      createFile(sub1Sub, "medium1Song3.mp3"))
+    val sub2 = createDir(dir1, "anotherSub")
+    val sub2Files = List(createFile(sub2, "song.mp3"))
+    val dir2Files = List(
+      createFile(dir2, "medium2Song1.mp3"),
+      createFile(dir2, "medium2Song2.mp3")
+    )
+    val sub3 = createDir(dir2, "medium2Sub")
+    val sub3Files = List(createFile(sub3, "medium2Song3.mp3"))
+
+    Map(testDirectory -> rootFiles, dir1 -> dir1Files, sub1 -> sub1Files, sub1Sub ->
+      sub1SubFiles, sub2 -> sub2Files, dir2 -> dir2Files, sub3 -> sub3Files)
+  }
+
+  /**
+   * Returns a sink for collecting the items produced by the test source.
+   *
+   * @return the sink
+   */
+  private def foldSink(): Sink[WalkItem, Future[List[WalkItem]]] =
+    Sink.fold[List[WalkItem], WalkItem](List.empty[WalkItem])((lst, p) => p :: lst)
+
+  /**
+   * Runs a stream with the given source and returns a future with the 
+   * collected items.
+   *
+   * @param source the source to be tested
+   * @return a [[Future]] with the data obtained from the source
+   */
+  private def runSource(source: Source[WalkItem, NotUsed]): Future[List[WalkItem]] =
+    source.runWith(foldSink()).map(_.reverse)
+
+  /**
+   * Creates a [[FileSystem]] that can be used for testing the walk
+   * functionality. The implementation created here only defines the bare
+   * minimum of operations.
+   *
+   * @return the [[FileSystem]] to be used for tests
+   */
+  private def createFileSystem(): FileSystem[Path, WalkFile, WalkFolder, WalkFolderContent] =
+    new FileSystem[Path, WalkFile, WalkFolder, WalkFolderContent] {
+      override def resolvePath(path: String)(implicit system: typed.ActorSystem[_]): FileSystem.Operation[Path] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def rootID(implicit system: typed.ActorSystem[_]): FileSystem.Operation[Path] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def resolveFile(id: Path)(implicit system: typed.ActorSystem[_]): FileSystem.Operation[WalkFile] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def resolveFolder(id: Path)(implicit system: typed.ActorSystem[_]): FileSystem.Operation[WalkFolder] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def folderContent(id: Path)
+                                (implicit system: typed.ActorSystem[_]): FileSystem.Operation[WalkFolderContent] =
+        Operation { _ =>
+          Future {
+            val children = id.toFile.listFiles()
+            val (subFiles, subFolders) = children.partition(_.isFile)
+            val contentFiles = subFiles.map { f =>
+              f.toPath -> WalkSpec.createFile(f)
+            }.toMap
+            val contentFolders = subFolders.map { f =>
+              f.toPath -> WalkSpec.createFolder(f)
+            }.toMap
+            Model.FolderContent(id, contentFiles, contentFolders)
+          }(system.executionContext)
+        }
+
+      override def createFolder(parent: Path, folder: Model.Folder[Path])
+                               (implicit system: typed.ActorSystem[_]): FileSystem.Operation[Path] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def updateFolder(folder: Model.Folder[Path])
+                               (implicit system: typed.ActorSystem[_]): FileSystem.Operation[Unit] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def deleteFolder(folderID: Path)(implicit system: typed.ActorSystem[_]): FileSystem.Operation[Unit] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def createFile(parent: Path, file: Model.File[Path], content: Source[ByteString, Any])
+                             (implicit system: typed.ActorSystem[_]): FileSystem.Operation[Path] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def updateFile(file: Model.File[Path])
+                             (implicit system: typed.ActorSystem[_]): FileSystem.Operation[Unit] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def updateFileContent(fileID: Path, size: Long, content: Source[ByteString, Any])
+                                    (implicit system: typed.ActorSystem[_]): FileSystem.Operation[Unit] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def downloadFile(fileID: Path)
+                               (implicit system: typed.ActorSystem[_]): FileSystem.Operation[HttpEntity] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+
+      override def deleteFile(fileID: Path)(implicit system: typed.ActorSystem[_]): FileSystem.Operation[Unit] =
+        throw new UnsupportedOperationException("Unexpected invocation.")
+    }
+
+  "Walk" should "return all files in the scanned BFS directory structure" in {
+    val fileData = setUpDirectoryStructure()
+    val allFiles = fileData.values.flatten.toSeq
+
+    val source = Walk.bfsSource(createFileSystem(), null, testDirectory)
+    runSource(source).map(elements => elements.filter(_.isInstanceOf[WalkFile])).map { files =>
+      files map (_.id) should contain theSameElementsAs allFiles
+    }
+  }
+
+  it should "return all folders in the scanned BFS directory structure" in {
+    val fileData = setUpDirectoryStructure()
+    val expectedFolders = fileData.keySet - testDirectory
+
+    val source = Walk.bfsSource(createFileSystem(), null, testDirectory)
+    runSource(source).map(elements => elements.filter(_.isInstanceOf[WalkFolder])).map { folders =>
+      folders map (_.id) should contain theSameElementsAs expectedFolders
+    }
+  }
+
+  it should "correctly resolve a larger number of folders" in {
+    val FolderCount = 32
+    val root = Files.createDirectory(testDirectory.resolve("iterationRoot"))
+    (1 to FolderCount).foreach { idx =>
+      val folder = Files.createDirectory(root.resolve(s"sub$idx"))
+      writeFileContent(folder.resolve(s"testFile$idx.txt"), s"This is test file $idx.")
+    }
+    val expectedNames = (1 to FolderCount).flatMap { idx => List(s"sub$idx", s"testFile$idx.txt")}
+
+    val source = Walk.bfsSource(createFileSystem(), null, testDirectory)
+
+    runSource(source).map { elements =>
+      val names = elements.map(_.name)
+      names should contain allElementsOf expectedNames
+    }
+  }
+
+  it should "support an empty iteration in BFS order" in {
+    val source = Walk.bfsSource(createFileSystem(), null, testDirectory)
+
+    runSource(source).map { elements =>
+      elements shouldBe empty
+    }
+  }
+
+  it should "support iteration in BFS order" in {
+    @tailrec def calcLevel(p: Path, dist: Int): Int =
+      if (testDirectory == p) dist
+      else calcLevel(p.getParent, dist + 1)
+
+    def level(p: Path): Int = calcLevel(p, 0)
+
+    setUpDirectoryStructure()
+    val source = Walk.bfsSource(createFileSystem(), null, testDirectory)
+
+    runSource(source) map { paths =>
+      val pathLevels = paths map (d => level(d.id))
+      val compareLevels = pathLevels.drop(1) :+ Int.MaxValue
+
+      forAll(pathLevels.zip(compareLevels)) { t => t._1 should be <= t._2 }
+    }
+  }
+}

--- a/crypt-algs/aes/src/main/scala/com/github/cloudfiles/crypt/alg/aes/Aes.scala
+++ b/crypt-algs/aes/src/main/scala/com/github/cloudfiles/crypt/alg/aes/Aes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt-algs/aes/src/test/scala/com/github/cloudfiles/crypt/alg/aes/AesSpec.scala
+++ b/crypt-algs/aes/src/test/scala/com/github/cloudfiles/crypt/alg/aes/AesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/alg/CryptAlgorithm.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/alg/CryptAlgorithm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/alg/CryptCipher.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/alg/CryptCipher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/CryptConfig.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/CryptConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/CryptContentFileSystem.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/CryptContentFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/CryptNamesFileSystem.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/CryptNamesFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/resolver/CachePathComponentsResolver.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/resolver/CachePathComponentsResolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/resolver/PathComponentsResolver.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/resolver/PathComponentsResolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/resolver/PathResolver.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/fs/resolver/PathResolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/service/CryptService.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/service/CryptService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/main/scala/com/github/cloudfiles/crypt/service/CryptStage.scala
+++ b/crypt/src/main/scala/com/github/cloudfiles/crypt/service/CryptStage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/alg/ShiftCryptAlgorithm.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/alg/ShiftCryptAlgorithm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/CryptContentFileSystemSpec.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/CryptContentFileSystemSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/CryptFileSystemTestHelper.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/CryptFileSystemTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/CryptNamesFileSystemSpec.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/CryptNamesFileSystemSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/resolver/CachePathComponentsResolverSpec.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/resolver/CachePathComponentsResolverSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/resolver/PathComponentsResolverSpec.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/fs/resolver/PathComponentsResolverSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/service/CryptServiceSpec.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/service/CryptServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/crypt/src/test/scala/com/github/cloudfiles/crypt/service/CryptStageSpec.scala
+++ b/crypt/src/test/scala/com/github/cloudfiles/crypt/service/CryptStageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveConfig.scala
+++ b/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveFileSystem.scala
+++ b/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveJsonProtocol.scala
+++ b/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveJsonProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveModel.scala
+++ b/gdrive/src/main/scala/com/github/cloudfiles/gdrive/GoogleDriveModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/test/scala/com/github/cloudfiles/gdrive/GoogleDriveFileSystemITSpec.scala
+++ b/gdrive/src/test/scala/com/github/cloudfiles/gdrive/GoogleDriveFileSystemITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/test/scala/com/github/cloudfiles/gdrive/GoogleDriveJsonProtocolSpec.scala
+++ b/gdrive/src/test/scala/com/github/cloudfiles/gdrive/GoogleDriveJsonProtocolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/gdrive/src/test/scala/com/github/cloudfiles/gdrive/GoogleDriveModelSpec.scala
+++ b/gdrive/src/test/scala/com/github/cloudfiles/gdrive/GoogleDriveModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/localfs/src/main/scala/com/github/cloudfiles/localfs/LocalFileSystem.scala
+++ b/localfs/src/main/scala/com/github/cloudfiles/localfs/LocalFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/localfs/src/main/scala/com/github/cloudfiles/localfs/LocalFsConfig.scala
+++ b/localfs/src/main/scala/com/github/cloudfiles/localfs/LocalFsConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/localfs/src/main/scala/com/github/cloudfiles/localfs/LocalFsModel.scala
+++ b/localfs/src/main/scala/com/github/cloudfiles/localfs/LocalFsModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/localfs/src/test/scala/com/github/cloudfiles/localfs/LocalFileSystemSpec.scala
+++ b/localfs/src/test/scala/com/github/cloudfiles/localfs/LocalFileSystemSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/localfs/src/test/scala/com/github/cloudfiles/localfs/LocalFsModelSpec.scala
+++ b/localfs/src/test/scala/com/github/cloudfiles/localfs/LocalFsModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveConfig.scala
+++ b/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveFileSystem.scala
+++ b/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveJsonProtocol.scala
+++ b/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveJsonProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveModel.scala
+++ b/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveUpload.scala
+++ b/onedrive/src/main/scala/com/github/cloudfiles/onedrive/OneDriveUpload.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveFileSystemITSpec.scala
+++ b/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveFileSystemITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveJsonProtocolSpec.scala
+++ b/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveJsonProtocolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveModelSpec.scala
+++ b/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveUploadSpec.scala
+++ b/onedrive/src/test/scala/com/github/cloudfiles/onedrive/OneDriveUploadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/main/scala/com/github/cloudfiles/webdav/DavConfig.scala
+++ b/webdav/src/main/scala/com/github/cloudfiles/webdav/DavConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/main/scala/com/github/cloudfiles/webdav/DavFileSystem.scala
+++ b/webdav/src/main/scala/com/github/cloudfiles/webdav/DavFileSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/main/scala/com/github/cloudfiles/webdav/DavModel.scala
+++ b/webdav/src/main/scala/com/github/cloudfiles/webdav/DavModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/main/scala/com/github/cloudfiles/webdav/DavParser.scala
+++ b/webdav/src/main/scala/com/github/cloudfiles/webdav/DavParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/main/scala/com/github/cloudfiles/webdav/PropRequestGenerator.scala
+++ b/webdav/src/main/scala/com/github/cloudfiles/webdav/PropRequestGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/main/scala/com/github/cloudfiles/webdav/package.scala
+++ b/webdav/src/main/scala/com/github/cloudfiles/webdav/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/test/scala/com/github/cloudfiles/webdav/DavFileSystemITSpec.scala
+++ b/webdav/src/test/scala/com/github/cloudfiles/webdav/DavFileSystemITSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/test/scala/com/github/cloudfiles/webdav/DavModelSpec.scala
+++ b/webdav/src/test/scala/com/github/cloudfiles/webdav/DavModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/test/scala/com/github/cloudfiles/webdav/DavParserSpec.scala
+++ b/webdav/src/test/scala/com/github/cloudfiles/webdav/DavParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/webdav/src/test/scala/com/github/cloudfiles/webdav/PropRequestGeneratorSpec.scala
+++ b/webdav/src/test/scala/com/github/cloudfiles/webdav/PropRequestGeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The Developers Team.
+ * Copyright 2020-2025 The Developers Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR (among other things) introduces a new `Walk` object in the _core_ module that allows iterating over folder structures on a file system.