### PR TITLE
Add a generic retry extension actor

### DIFF
--- a/ReleaseNotes.adoc
+++ b/ReleaseNotes.adoc
@@ -6,7 +6,8 @@ of the CloudFiles library.
 == Release 0.10 (TBD)
 
 * The API of the `Walk` object in the _core_ module has been changed. Instead of expecting a larger number of parameters for the walk operation, the functions now accept an instance of the new `WalkConfig` class. This class has properties that correspond to the original function parameters. It allows extending the API without breaking backwards compatibility.
-* Via new properties in the `WalkConfig` class, it is now possible to further fine-tune walk operations with regard to fetching the content of folders. Clients can specify how many folders should be resolved in parallel, and how many folders in the processing queue should already be resolved. These properties can make iterations more efficient by increasing parallelism
+* Via new properties in the `WalkConfig` class, it is now possible to further fine-tune walk operations with regard to fetching the content of folders. Clients can specify how many folders should be resolved in parallel, and how many folders in the processing queue should already be resolved. These properties can make iterations more efficient by increasing parallelism.
+* Added a new `RetryExtension` actor to the `http` package of the _core_ module. This extension actor implements a generic and flexible retry mechanism for HTTP requests.
 
 == Release 0.9 (2025-03-22)
 

--- a/core/README.adoc
+++ b/core/README.adoc
@@ -80,10 +80,20 @@ In addition, the configuration can contain a function the actor invokes when it 
 
 NOTE: This extension actor does not provide any functionality to obtain an access and refresh token pair initially. The reason is that there are many different OAuth flows for different kinds of client applications and use cases. So, a concrete application has to implement the mechanism that it fits best. One example how this could look like is the https://github.com/oheger/stream-sync[StreamSync] application which uses the CloudFiles library to access Microsoft OneDrive and Google Drive storages via their native OAuth-based authentication mechanisms. It has some helper classes for interacting with OAuth identity providers; there is even a CLI tool supporting an interactive flow which opens a web browser and let the user fill out a login form from the identity provider. Some documentation about setting up OAuth clients for OneDrive and Google Drive is available in the StreamSync documentation under https://github.com/oheger/stream-sync/tree/main#sync-from-a-local-directory-to-microsoft-onedrive and https://github.com/oheger/stream-sync/tree/main#sync-from-a-local-directory-to-google-drive.
 
+[#retry_after_extension]
 === RetryAfterExtension
 The purpose of this extension actor implementation is to deal with responses of the failure status 429 _Too many requests_. Practice has shown that some service providers enforce a rate limit that can be reached when executing many operations in a short time, e.g. when trying to upload a larger number of small files. In this case, the server responds with the error code 429, and the response typically contains a `Retry-After` header that defines a delay until when another request will be accepted.
 
 `RetryAfterExtension` intercepts responses with this error code and evaluates the `Retry-After` header if it is present. If the header cannot be found or has an unexpected format, a configurable delay is used instead. The actor then waits for this time span, and afterward retries the request. Ideally, this new request is now successful; otherwise, the same steps are performed again.
+
+=== RetryExtension
+While <<retry_after_extension>> implements a retry mechanism for a specific failure code, this extension actor can handle generic error conditions and supports a flexible retry strategy. The following aspects can be configured:
+
+* A function that determines for which responses a retry should be done. The function is passed the result object from the original sender actor and can base its decision on all properties available here. So, a retry is not limited to failure responses, but other criteria could be used as well.
+* The number of times a retry should be attempted. When this limit is reached, the actor gives up and returns the last failure result that was received.
+* An exponential backoff for retry attempts. So, a retry is not performed immediately after a failure, but with an increasing delay every time another failure is received.
+
+Together, these properties allow for a fine-grained configuration of the retry mechanism.
 
 === HttpRequestSenderFactory
 The extension mechanism supported by the HTTP-related utilities requires that a number of actors are created and linked together in a chain. This is in the responsibility of client applications. A frequent use case is that such a chain of extensions has to be constructed dynamically based on configuration. This is especially useful if CloudFiles is used as an abstraction over different protocols, and a concrete protocol is selected dynamically. Often, the chain of HTTP actors then depends on the selected protocol and/or the target server to interact with.

--- a/core/src/main/scala/com/github/cloudfiles/core/http/RetryExtension.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/RetryExtension.scala
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2020-2025 The Developers Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.cloudfiles.core.http
+
+import com.github.cloudfiles.core.http.HttpRequestSender.FailedResponseException
+import org.apache.pekko.actor.Cancellable
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, ActorSystem, Behavior, SupervisorStrategy}
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+
+import scala.concurrent.duration._
+
+/**
+ * An extension actor that implements a generic retry mechanism for HTTP
+ * requests.
+ *
+ * This extension actor supports a fine-grained configuration under which
+ * circumstances and how a request should be retried. It is possible to specify
+ * the number of retries for a single request. Also, an exponential backoff is
+ * supported. The actor uses a function to determine whether a request should
+ * be retried; so, the mechanism does not only work for failed requests but can
+ * perform arbitrary checks of the received response.
+ */
+object RetryExtension {
+  /**
+   * An alias for a function that is used by this actor to determine whether a
+   * request should be retried. The function is passed the result received from
+   * the HTTP sender actor and can decide whether to retry the request (in
+   * which case it has to return '''true''') or not (in which case it has to
+   * return '''false''').
+   */
+  type RetryCheckFunc = HttpRequestSender.Result => Boolean
+
+  /**
+   * A data class defining the configuration for retry behavior with
+   * exponential backoff. The properties of this class correspond to the
+   * restart facilities supported by actor supervision. Basically, a retry is
+   * attempted after increasing durations between the given minimum and maximum
+   * backoff durations; an optional random factor can be used to increase the
+   * delay to avoid deterministic behavior.
+   *
+   * @param minBackoff   the minimum backoff duration
+   * @param maxBackoff   the maximum backoff duration
+   * @param randomFactor the random factor to increase the delay
+   */
+  case class BackoffConfig(minBackoff: FiniteDuration,
+                           maxBackoff: FiniteDuration,
+                           randomFactor: Double = 0)
+
+  /**
+   * A data class defining the configuration for the retry extension actor.
+   *
+   * @param optMaxTimes        the optional maximum number of time a retry is
+   *                           attempted; if this number is reached, the actor
+   *                           responds with the latest failure response; if
+   *                           undefined, the actor retries all requests until
+   *                           it receives a success response
+   * @param optBackoff         the optional configuration for an exponential
+   *                           backoff; if undefined, a retry happens
+   *                           immediately
+   * @param retryCheckFunc     the function to determine whether to retry a
+   *                           request or not; the default function retries all
+   *                           requests that yield a failed response; n.b. that
+   *                           requests that fail completely (without
+   *                           generating a response) are '''not''' retried
+   * @param discardEntityAfter a timeout when to discard the entity of a failed
+   *                           response; a failed response is buffered for a
+   *                           while, since it is not immediately known whether
+   *                           a retry can happen or not; after buffering the
+   *                           response for this time, discarding of the entity
+   *                           is enforced; it is usually not necessary to
+   *                           change this value; it is used mainly internally
+   *                           for testing purposes
+   */
+  case class RetryConfig(optMaxTimes: Option[Int] = None,
+                         optBackoff: Option[BackoffConfig] = None,
+                         retryCheckFunc: RetryCheckFunc = RetryOnFailure,
+                         discardEntityAfter: FiniteDuration = DefaultDiscardEntityAfter)
+
+  /**
+   * A default [[RetryCheckFunc]] implementation that triggers a retry if the
+   * status code of the response indicates a failure. If there is no response
+   * at all, no retry is attempted.
+   */
+  private val RetryOnFailure: RetryCheckFunc = {
+    case HttpRequestSender.FailedResult(_, FailedResponseException(_)) => true
+    case _ => false
+  }
+
+  /** A default timeout after which a response entity gets discarded. */
+  private val DefaultDiscardEntityAfter = 900.millis
+
+  /**
+   * A trait defining the base command processed by the actor responsible for
+   * the implementation of the retry logic.
+   */
+  private sealed trait RetryExtensionCommand
+
+  /**
+   * A command that instructs the retry actor to start processing of a new
+   * request.
+   *
+   * @param request the request to process
+   */
+  private case class HandleRequest(request: HttpRequestSender.SendRequest) extends RetryExtensionCommand
+
+  /**
+   * A command that notifies the retry actor about a result becoming available
+   * for a specific request. The result is stored, so that it can be sent to
+   * the original caller once it is known to be final.
+   *
+   * @param index  the index of the request
+   * @param result the result to store
+   */
+  private case class ResultReceived(index: Long,
+                                    result: HttpRequestSender.Result) extends RetryExtensionCommand
+
+  /**
+   * A command that notifies the retry actor that the handler actor for a
+   * specific request has stopped. This means that this request is now done
+   * (either in success or failure state), and the last response can be sent to
+   * the caller.
+   *
+   * @param index the index of the affected request
+   */
+  private case class RequestHandlerStopped(index: Long) extends RetryExtensionCommand
+
+  /**
+   * A command that notifies the retry actor that the timeout for discarding a
+   * response entity is now reached. This means that the request is retried,
+   * and the affected result is not sent to the caller. On handling this
+   * command, the actor discards the bytes of the response entity.
+   *
+   * @param response the affected response
+   */
+  private case class DiscardResponseEntityTimeout(response: HttpResponse) extends RetryExtensionCommand
+
+  /**
+   * A data class storing information about a single request that is currently
+   * processed by this actor. The class is used to keep track about the results
+   * already received, so that it is always possible to inform the original
+   * client even if a retry is no longer possible.
+   *
+   * @param lastResult         the last result received from the sender actor
+   * @param discardCancellable the object to cancel the postponed discarding
+   *                           of the response entity if available
+   */
+  private case class RequestState(lastResult: HttpRequestSender.Result,
+                                  discardCancellable: Option[Cancellable])
+
+  /**
+   * A data class holding the current state of the actor that handles requests
+   * with retry logic.
+   *
+   * @param requestSender the actor for sending requests
+   * @param config        the configuration for this extension actor
+   * @param requestCount  the counter for processed requests to generate
+   *                      unique identifiers
+   * @param requests      a map with the requests currently in progress
+   */
+  private case class RetryActorState(requestSender: ActorRef[HttpRequestSender.HttpCommand],
+                                     config: RetryConfig,
+                                     requestCount: Long,
+                                     requests: Map[Long, RequestState])
+
+  /**
+   * Returns the behavior of a new actor instance that forwards to the given
+   * request sender actor and uses the specified configuration.
+   *
+   * @param requestSender the request sender to decorate
+   * @param config        the configuration for this extension actor
+   * @return the behavior of the new actor
+   */
+  def apply(requestSender: ActorRef[HttpRequestSender.HttpCommand],
+            config: RetryConfig): Behavior[HttpRequestSender.HttpCommand] =
+    Behaviors.setup[HttpRequestSender.HttpCommand] { context =>
+      val retryState = RetryActorState(
+        requestSender = requestSender,
+        config = config,
+        requestCount = 0,
+        requests = Map.empty
+      )
+      val retryActor = context.spawnAnonymous(handleRequestWithRetry(retryState))
+
+      Behaviors.receiveMessagePartial {
+        case request: HttpRequestSender.SendRequest =>
+          retryActor ! HandleRequest(request)
+          Behaviors.same
+
+        case HttpRequestSender.Stop =>
+          requestSender ! HttpRequestSender.Stop
+          Behaviors.stopped
+      }
+    }
+
+  /**
+   * The main command handler function of the actor implementing the logic for
+   * processing requests. The idea here is to have a temporary actor that does
+   * the forwarding of the request to the sender actor and that crashes itself
+   * on a failed request. By using a proper resume strategy, the retry logic is
+   * enforced automatically: the actor will be restarted as configured and
+   * every time send another request until the request succeeds or the
+   * supervisor strategy decides that it is enough.
+   *
+   * @param state the current state of this actor
+   * @return the behavior for the retry actor
+   */
+  private def handleRequestWithRetry(state: RetryActorState): Behavior[RetryExtensionCommand] =
+    Behaviors.receive {
+      case (context, HandleRequest(request)) =>
+        val nextIndex = state.requestCount + 1
+        val requestBehavior = handleSendRequest(
+          context.self,
+          state.requestSender,
+          request,
+          state.config.retryCheckFunc,
+          nextIndex
+        )
+        val requestActor = context.spawnAnonymous(supervise(state.config, requestBehavior))
+        context.watchWith(requestActor, RequestHandlerStopped(nextIndex))
+        handleRequestWithRetry(state.copy(requestCount = nextIndex))
+
+      case (context, ResultReceived(index, result)) =>
+        val discardCancellable = extractResponse(result).map { response =>
+          context.scheduleOnce(state.config.discardEntityAfter, context.self, DiscardResponseEntityTimeout(response))
+        }
+        val requestState = RequestState(result, discardCancellable)
+        val nextState = state.copy(requests = state.requests + (index -> requestState))
+        handleRequestWithRetry(nextState)
+
+      case (context, DiscardResponseEntityTimeout(response)) =>
+        implicit val mat: ActorSystem[Nothing] = context.system
+        response.entity.discardBytes()
+        Behaviors.same
+
+      case (_, RequestHandlerStopped(index)) =>
+        state.requests.get(index).map { requestState =>
+          requestState.lastResult.request.replyTo ! requestState.lastResult
+          requestState.discardCancellable.foreach(_.cancel())
+          val nextState = state.copy(requests = state.requests - index)
+          handleRequestWithRetry(nextState)
+        }.getOrElse(Behaviors.same)
+    }
+
+  /**
+   * The command handler function of a temporary actor that is responsible for
+   * a single request. The actor passes the request to the request sender actor
+   * and evaluates the result. The result is always passed to the controller
+   * actor. In case of a failure, this actor crashes to force supervision to
+   * kick in.
+   *
+   * @param controller    the actor controlling the retry logic
+   * @param requestSender the actor for sending requests
+   * @param request       the request to be handled
+   * @param checkFunc     the function to check for failed requests
+   * @param index         the index of this actor (used as ID)
+   * @return the behavior for the request handler actor
+   */
+  private def handleSendRequest(controller: ActorRef[RetryExtensionCommand],
+                                requestSender: ActorRef[HttpRequestSender.HttpCommand],
+                                request: HttpRequestSender.SendRequest,
+                                checkFunc: RetryCheckFunc,
+                                index: Long): Behavior[HttpRequestSender.HttpCommand] =
+    Behaviors.setup[HttpRequestSender.HttpCommand] { context =>
+      val requestStr = s"${request.request.method} ${request.request.uri}"
+      HttpRequestSender.forwardRequest(context, requestSender, request.request, request, request.discardEntityMode)
+
+      Behaviors.receiveMessagePartial {
+        case HttpRequestSender.ForwardedResult(fwdResult) =>
+          val result = HttpRequestSender.resultFromForwardedRequest(fwdResult)
+          controller ! ResultReceived(index, result)
+          if (checkFunc(result)) {
+            // The result is not accepted; so crash to trigger a restart if possible.
+            context.log.warn("Received an unaccepted response for {}.", requestStr)
+            throw new RuntimeException(requestStr)
+          } else {
+            Behaviors.stopped
+          }
+      }
+    }
+
+  /**
+   * Returns a [[Behavior]] based on the passed in one that is supervised by a
+   * strategy compatible with the given configuration.
+   *
+   * @param config   the configuration for the retry extension
+   * @param behavior the original [[Behavior]]
+   * @return the supervised [[Behavior]]
+   */
+  private def supervise(config: RetryConfig, behavior: Behavior[HttpRequestSender.HttpCommand]):
+  Behavior[HttpRequestSender.HttpCommand] =
+    Behaviors.supervise(behavior).onFailure[Throwable](supervisionStrategy(config))
+
+  /**
+   * Returns a [[SupervisorStrategy]] that is compatible with the passed in
+   * configuration.
+   *
+   * @param config the configuration for the retry extension
+   * @return the [[SupervisorStrategy]] that follows this configuration
+   */
+  private def supervisionStrategy(config: RetryConfig): SupervisorStrategy =
+    config.optBackoff match {
+      case Some(backOffConfig) =>
+        val strategy = SupervisorStrategy.restartWithBackoff(
+          backOffConfig.minBackoff,
+          backOffConfig.maxBackoff,
+          backOffConfig.randomFactor
+        )
+        config.optMaxTimes.fold(strategy)(times => strategy.withMaxRestarts(times))
+      case None =>
+        val strategy = SupervisorStrategy.restart
+        config.optMaxTimes.fold(strategy)(times => strategy.withLimit(times, 1.day))
+    }
+
+  /**
+   * Extracts the [[HttpResponse]] from the given result if it is available.
+   *
+   * @param result the result
+   * @return an [[Option]] with the extracted result
+   */
+  private def extractResponse(result: HttpRequestSender.Result): Option[HttpResponse] =
+    result match {
+      case HttpRequestSender.SuccessResult(_, response) => Some(response)
+      case HttpRequestSender.FailedResult(request, FailedResponseException(response))
+        if request.discardEntityMode == HttpRequestSender.DiscardEntityMode.Never => Some(response)
+      case _ => None
+    }
+}

--- a/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderConfig.scala
+++ b/core/src/main/scala/com/github/cloudfiles/core/http/factory/HttpRequestSenderConfig.scala
@@ -19,6 +19,7 @@ package com.github.cloudfiles.core.http.factory
 import com.github.cloudfiles.core.http.HttpRequestSender
 import com.github.cloudfiles.core.http.ProxySupport.{ProxySelectorFunc, SystemProxy}
 import com.github.cloudfiles.core.http.RetryAfterExtension.RetryAfterConfig
+import com.github.cloudfiles.core.http.RetryExtension.RetryConfig
 import com.github.cloudfiles.core.http.auth.{AuthConfig, NoAuthConfig}
 
 /**
@@ -41,9 +42,12 @@ import com.github.cloudfiles.core.http.auth.{AuthConfig, NoAuthConfig}
  * @param proxy            the function to select the proxy
  * @param retryAfterConfig an optional configuration for a ''RetryAfter''
  *                         extension; if present, such an extension is created
+ * @param retryConfig      an optional configuration for a ''Retry'' extension;
+ *                         if present, such an extension is created
  */
 case class HttpRequestSenderConfig(actorName: Option[String] = None,
                                    authConfig: AuthConfig = NoAuthConfig,
                                    queueSize: Int = HttpRequestSender.DefaultQueueSize,
                                    proxy: ProxySelectorFunc = SystemProxy,
-                                   retryAfterConfig: Option[RetryAfterConfig] = None)
+                                   retryAfterConfig: Option[RetryAfterConfig] = None,
+                                   retryConfig: Option[RetryConfig] = None)

--- a/core/src/test/scala/com/github/cloudfiles/core/http/RetryAfterExtensionSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/RetryAfterExtensionSpec.scala
@@ -16,11 +16,10 @@
 
 package com.github.cloudfiles.core.http
 
-import com.github.cloudfiles.core.http.HttpRequestSender.DiscardEntityMode.DiscardEntityMode
 import com.github.cloudfiles.core.http.HttpRequestSender.{DiscardEntityMode, FailedResponseException}
 import com.github.cloudfiles.core.http.RetryAfterExtension.RetryAfterConfig
-import org.apache.pekko.actor.testkit.typed.scaladsl.{BehaviorTestKit, ScalaTestWithActorTestKit}
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import com.github.cloudfiles.core.http.RetryTestHelper.failedResult
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.model.headers.`Retry-After`
 import org.mockito.Mockito.{never, verify}
@@ -29,30 +28,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration._
-
-object RetryAfterExtensionSpec {
-  /** A test HTTP request sent to the test actor. */
-  private val TestRequest = HttpRequest(uri = "https://example.org/foo")
-
-  /** A data object associated with the test request. */
-  private val RequestData = "someRequestData"
-
-  /**
-   * Creates a failed result object with a response that failed with the status
-   * code provided.
-   *
-   * @param request the request to be answered
-   * @param status  the status code
-   * @param headers headers of the response
-   * @param entity  an optional response entity
-   * @return the resulting ''FailedResult'' object
-   */
-  private def failedResult(request: HttpRequestSender.SendRequest, status: StatusCode,
-                           headers: List[HttpHeader] = Nil, entity: ResponseEntity = HttpEntity.Empty):
-  HttpRequestSender.FailedResult =
-    HttpRequestSender.FailedResult(request,
-      FailedResponseException(HttpResponse(status = status, headers = headers, entity = entity)))
-}
 
 /**
  * Test class for ''RetryAfterExtension''.
@@ -65,12 +40,17 @@ object RetryAfterExtensionSpec {
  * check whether results arrive in a specific time frame or not.
  */
 class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpecLike with Matchers with MockitoSugar {
-
-  import RetryAfterExtensionSpec._
+  /**
+   * Creates the [[RetryTestHelper]] with the correct behavior to test.
+   *
+   * @return the test helper
+   */
+  private def createHelper(): RetryTestHelper =
+    new RetryTestHelper(testKit, this)(sender => RetryAfterExtension(sender, RetryAfterConfig(1.second)))
 
   "RetryAfterExtension" should "handle a successful request" in {
     val response = HttpResponse(status = StatusCodes.Accepted)
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     val result = helper.sendTestRequest()
       .checkAndAnswerForwardedRequest { fwdRequest =>
@@ -81,7 +61,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
   }
 
   it should "propagate the discard entity mode when forwarding a request" in {
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     val fwdRequest = helper.sendTestRequest(DiscardEntityMode.Always)
       .expectForwardedRequest()
@@ -90,7 +70,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
 
   it should "handle a failed request" in {
     val exception = new IllegalArgumentException("An exception")
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     val result = helper.sendTestRequest()
       .checkAndAnswerForwardedRequest {
@@ -101,7 +81,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
   }
 
   it should "handle a request that failed with another status code" in {
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     val result = helper.sendTestRequest()
       .checkAndAnswerForwardedRequest {
@@ -117,7 +97,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
 
   it should "handle a request failing with status 429 without a retry-after header" in {
     val responseEntity = mock[ResponseEntity]
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     helper.sendTestRequest()
       .checkAndAnswerForwardedRequest {
@@ -132,7 +112,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
 
   it should "handle a request failing with status 429 with a retry-after header and a delay" in {
     val headers = List(`Retry-After`(1))
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     helper.sendTestRequest()
       .checkAndAnswerForwardedRequest {
@@ -148,7 +128,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
     val now = DateTime.now
     val dateAfter = now + 500 // millis
     val headers = List(`Retry-After`(dateAfter))
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     helper.sendTestRequest()
       .checkAndAnswerForwardedRequest {
@@ -164,7 +144,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
     val now = DateTime.now
     val dateAfter = now + 1.minute.toMillis
     val headers = List(`Retry-After`(dateAfter))
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     helper.sendTestRequest()
       .checkAndAnswerForwardedRequest { fwdRequest =>
@@ -174,7 +154,7 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
 
   it should "discard the entity when retrying a request in discard mode Never" in {
     val responseEntity = mock[ResponseEntity]
-    val helper = new RetryTestHelper
+    val helper = createHelper()
 
     helper.sendTestRequest(DiscardEntityMode.Never)
       .checkAndAnswerForwardedRequest {
@@ -188,108 +168,8 @@ class RetryAfterExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpec
   }
 
   it should "react on a Stop message" in {
-    val probeRequest = testKit.createTestProbe[HttpRequestSender.HttpCommand]()
-    val btk = BehaviorTestKit(RetryAfterExtension(probeRequest.ref))
+    val helper = createHelper()
 
-    btk.run(HttpRequestSender.Stop)
-    btk.returnedBehavior should be(Behaviors.stopped)
-    probeRequest.expectMessage(HttpRequestSender.Stop)
+    helper.checkHandlingOfStopMessage()
   }
-
-  /**
-   * A test helper class managing an actor to tests and helper objects for
-   * this purpose.
-   */
-  private class RetryTestHelper {
-    /** A probe acting as the underlying request actor. */
-    private val probeRequest = testKit.createTestProbe[HttpRequestSender.HttpCommand]()
-
-    /** A probe acting as the client of the request actor. */
-    private val probeReply = testKit.createTestProbe[HttpRequestSender.Result]()
-
-    /** The extension to be tested. */
-    private val retryExtension = testKit.spawn(RetryAfterExtension(probeRequest.ref, RetryAfterConfig(1.second)))
-
-    /**
-     * Sends a test request to the test extension actor.
-     *
-     * @param discardMode the entity discard mode to set for this request
-     * @return this test helper
-     */
-    def sendTestRequest(discardMode: DiscardEntityMode = DiscardEntityMode.OnFailure): RetryTestHelper = {
-      val request = HttpRequestSender.SendRequest(TestRequest, RequestData, probeReply.ref, discardMode)
-      retryExtension ! request
-      this
-    }
-
-    /**
-     * Expects a forwarded request to be sent to the underlying request actor.
-     *
-     * @return the forwarded request
-     */
-    def expectForwardedRequest(): HttpRequestSender.SendRequest =
-      probeRequest.expectMessageType[HttpRequestSender.SendRequest]
-
-    /**
-     * Expects that a request is forwarded to the underlying request actor and
-     * sends a response.
-     *
-     * @param resultFunc a function to produce the result
-     * @tparam A the type of the result
-     * @return this test helper
-     */
-    def checkAndAnswerForwardedRequest[A <: HttpRequestSender.Result](resultFunc: HttpRequestSender.SendRequest => A):
-    RetryTestHelper = {
-      val fwdRequest = expectForwardedRequest()
-      fwdRequest.request should be(TestRequest)
-      val result = resultFunc(fwdRequest)
-      fwdRequest.replyTo ! result
-      this
-    }
-
-    /**
-     * Expects that a successful result is delivered to the client actor. Does
-     * some checks on the result.
-     *
-     * @return the result that was received
-     */
-    def expectSuccessResult(): HttpRequestSender.SuccessResult =
-      checkSendRequest(probeReply.expectMessageType[HttpRequestSender.SuccessResult])
-
-    /**
-     * Expects that a failure result is delivered to the client actor. Does
-     * some checks on the result.
-     *
-     * @return the result that was received
-     */
-    def expectFailureResult(): HttpRequestSender.FailedResult =
-      checkSendRequest(probeReply.expectMessageType[HttpRequestSender.FailedResult])
-
-    /**
-     * Checks that no message is forwarded to the underlying request actor in a
-     * specific time frame. This is used to test whether scheduling of retried
-     * requests works as expected.
-     *
-     * @return this test helper
-     */
-    def expectNoForwardedRequest(): RetryTestHelper = {
-      probeRequest.expectNoMessage(1500.millis)
-      this
-    }
-
-    /**
-     * Checks whether the request contained in the given result has the
-     * expected properties of the test request.
-     *
-     * @param result the result to check
-     * @tparam A the type of the result
-     * @return the same result
-     */
-    private def checkSendRequest[A <: HttpRequestSender.Result](result: A): A = {
-      result.request.data should be(RequestData)
-      result.request.request should be(TestRequest)
-      result
-    }
-  }
-
 }

--- a/core/src/test/scala/com/github/cloudfiles/core/http/RetryExtensionSpec.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/RetryExtensionSpec.scala
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2020-2025 The Developers Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.cloudfiles.core.http
+
+import com.github.cloudfiles.core.http.HttpRequestSender.{DiscardEntityMode, FailedResponseException}
+import com.github.cloudfiles.core.http.RetryTestHelper.{TestRequest, failedResult}
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, ResponseEntity, StatusCode, StatusCodes}
+import org.mockito.Mockito
+import org.mockito.Mockito.{never, verify}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.duration._
+
+/**
+ * Test class for [[RetryExtension]].
+ */
+class RetryExtensionSpec extends ScalaTestWithActorTestKit with AnyFlatSpecLike with Matchers with MockitoSugar {
+  /**
+   * Creates the [[RetryTestHelper]] with the correct behavior to test.
+   *
+   * @return the test helper
+   */
+  private def createHelper(config: RetryExtension.RetryConfig): RetryTestHelper =
+    new RetryTestHelper(testKit, this)(sender => RetryExtension(sender, config))
+
+  "RetryExtension" should "handle a successful request" in {
+    val response = HttpResponse(status = StatusCodes.Accepted)
+    val helper = createHelper(RetryExtension.RetryConfig())
+
+    val result = helper.sendTestRequest()
+      .checkAndAnswerForwardedRequest { fwdRequest =>
+        fwdRequest.discardEntityMode should be(DiscardEntityMode.OnFailure)
+        HttpRequestSender.SuccessResult(fwdRequest, response)
+      }.expectSuccessResult()
+    result.response should be(response)
+  }
+
+  it should "propagate the discard entity mode when forwarding a request" in {
+    val helper = createHelper(RetryExtension.RetryConfig())
+
+    val fwdRequest = helper.sendTestRequest(DiscardEntityMode.Always)
+      .expectForwardedRequest()
+    fwdRequest.discardEntityMode should be(DiscardEntityMode.Always)
+  }
+
+  it should "handle a failed request" in {
+    val exception = new IllegalArgumentException("An exception")
+    val helper = createHelper(RetryExtension.RetryConfig())
+
+    val result = helper.sendTestRequest()
+      .checkAndAnswerForwardedRequest {
+        HttpRequestSender.FailedResult(_, exception)
+      }
+      .expectFailureResult()
+    result.cause should be(exception)
+  }
+
+  it should "correctly evaluate the check function for retries" in {
+    val checkFunc: RetryExtension.RetryCheckFunc = result => {
+      result.request.request should be(RetryTestHelper.TestRequest)
+      result match {
+        case HttpRequestSender.FailedResult(_, HttpRequestSender.FailedResponseException(response)) =>
+          response.status != StatusCodes.BadRequest
+        case _ => true
+      }
+    }
+    val config = RetryExtension.RetryConfig(retryCheckFunc = checkFunc)
+    val helper = createHelper(config)
+
+    val result = helper.sendTestRequest()
+      .checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.BadRequest)
+      }
+      .expectFailureResult()
+    result.cause match {
+      case e: FailedResponseException =>
+        e.response.status should be(StatusCodes.BadRequest)
+      case e => fail("Unexpected exception: " + e)
+    }
+  }
+
+  it should "retry a failed request" in {
+    val responseEntity = mock[ResponseEntity]
+    val config = RetryExtension.RetryConfig(discardEntityAfter = 1.millis)
+    val helper = createHelper(config)
+
+    helper.sendTestRequest()
+      .checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.InternalServerError, entity = responseEntity)
+      }
+      .checkAndAnswerForwardedRequest {
+        HttpRequestSender.SuccessResult(_, HttpResponse())
+      }
+      .expectSuccessResult()
+    verify(responseEntity, never()).discardBytes()
+  }
+
+  it should "handle multiple parallel requests" in {
+    val otherClient = testKit.createTestProbe[HttpRequestSender.Result]()
+    val otherRequest = HttpRequestSender.SendRequest(
+      request = HttpRequest(uri = "https://example.com/bar"),
+      data = 0,
+      replyTo = otherClient.ref
+    )
+    val helper = createHelper(RetryExtension.RetryConfig())
+
+    val forwardedRequest1 = helper.sendTestRequest()
+      .expectForwardedRequest()
+    val forwardedRequest2 = helper.sendRequest(otherRequest)
+      .expectForwardedRequest()
+
+    forwardedRequest1.request should be(TestRequest)
+    forwardedRequest2.request should be(otherRequest.request)
+    val response1 = HttpRequestSender.SuccessResult(forwardedRequest1, HttpResponse())
+    val response2 = HttpRequestSender.SuccessResult(forwardedRequest2, HttpResponse(status = StatusCodes.Created))
+    forwardedRequest1.replyTo ! response1
+    forwardedRequest2.replyTo ! response2
+
+    helper.expectSuccessResult()
+    val result2 = otherClient.expectMessageType[HttpRequestSender.SuccessResult]
+    result2.response.status should be(StatusCodes.Created)
+  }
+
+  it should "discard the entity when retrying a request in discard mode Never" in {
+    val responseEntity = mock[ResponseEntity]
+    val config = RetryExtension.RetryConfig(discardEntityAfter = 10.millis)
+    val helper = createHelper(config)
+
+    helper.sendTestRequest(DiscardEntityMode.Never)
+      .checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.BadGateway, entity = responseEntity)
+      }
+      .checkAndAnswerForwardedRequest {
+        HttpRequestSender.SuccessResult(_, HttpResponse())
+      }
+      .expectSuccessResult()
+    verify(responseEntity, Mockito.timeout(1000)).discardBytes()
+  }
+
+  it should "retry a successful request if the check function demands this" in {
+    val responseEntity = mock[ResponseEntity]
+    val checkFunc: RetryExtension.RetryCheckFunc = {
+      case HttpRequestSender.SuccessResult(_, response) =>
+        response.status == StatusCodes.Accepted
+      case r =>
+        fail("Unexpected result: " + r)
+    }
+    val config = RetryExtension.RetryConfig(retryCheckFunc = checkFunc,
+      discardEntityAfter = 1.millis)
+    val helper = createHelper(config)
+
+    val result = helper.sendTestRequest(HttpRequestSender.DiscardEntityMode.Never)
+      .checkAndAnswerForwardedRequest {
+        HttpRequestSender.SuccessResult(_, HttpResponse(status = StatusCodes.Accepted, entity = responseEntity))
+      }
+      .checkAndAnswerForwardedRequest {
+        HttpRequestSender.SuccessResult(_, HttpResponse(status = StatusCodes.Created))
+      }
+      .expectSuccessResult()
+
+    result.response.status should be(StatusCodes.Created)
+    verify(responseEntity, Mockito.timeout(1000)).discardBytes()
+  }
+
+  it should "retry only for the configured number of times" in {
+    val RetryCount = 4
+    val config = RetryExtension.RetryConfig(optMaxTimes = Some(RetryCount))
+    val helper = createHelper(config)
+
+    helper.sendTestRequest()
+    (1 to RetryCount).foreach { _ =>
+      helper.checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.BadGateway)
+      }
+    }
+    val result = helper.checkAndAnswerForwardedRequest {
+      failedResult(_, StatusCodes.BadRequest)
+    }.expectFailureResult()
+    result.cause match {
+      case e: FailedResponseException =>
+        e.response.status should be(StatusCodes.BadRequest)
+      case e => fail("Unexpected exception: " + e)
+    }
+  }
+
+  it should "not discard the entity for the request passed to the caller" in {
+    val responseEntity = mock[ResponseEntity]
+    val config = RetryExtension.RetryConfig(optMaxTimes = Some(1), discardEntityAfter = 1.millis)
+    val helper = createHelper(config)
+
+    helper.sendTestRequest(HttpRequestSender.DiscardEntityMode.Never)
+      .checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.BadGateway)
+      }
+      .checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.BadGateway, entity = responseEntity)
+      }.expectFailureResult()
+
+    verify(responseEntity, never()).discardBytes()
+  }
+
+  /**
+   * Expects a forwarded request and sends a failure response. Returns the
+   * time (in nanos) when the request was received.
+   *
+   * @param helper the test helper
+   * @param status the status code for the failure response
+   * @return the time when the forwarded request was received
+   */
+  private def checkAndAnswerForwardedRequestWithTime(helper: RetryTestHelper,
+                                                     status: StatusCode = StatusCodes.BadGateway): Long = {
+    helper.checkAndAnswerForwardedRequest {
+      failedResult(_, status)
+    }
+    System.nanoTime()
+  }
+
+  it should "support retry with exponential backoff" in {
+    val backOffConfig = RetryExtension.BackoffConfig(50.millis, 10.seconds)
+    val config = RetryExtension.RetryConfig(optBackoff = Some(backOffConfig))
+    val helper = createHelper(config)
+
+    helper.sendTestRequest()
+    val failureTime = checkAndAnswerForwardedRequestWithTime(helper)
+    val retryTime1 = checkAndAnswerForwardedRequestWithTime(helper, StatusCodes.InternalServerError)
+    val retryTime2 = checkAndAnswerForwardedRequestWithTime(helper)
+
+    val delta1 = (retryTime1 - failureTime).nanos
+    delta1 should be >= 50.millis
+    val delta2 = (retryTime2 - retryTime1).nanos
+    delta2 should be >= 100.millis
+  }
+
+  it should "correctly evaluate the upper bound of exponential backoff" in {
+    val backOffConfig = RetryExtension.BackoffConfig(500.millis, 750.millis)
+    val config = RetryExtension.RetryConfig(optBackoff = Some(backOffConfig))
+    val helper = createHelper(config)
+
+    helper.sendTestRequest()
+    checkAndAnswerForwardedRequestWithTime(helper)
+    val retryTime1 = checkAndAnswerForwardedRequestWithTime(helper, StatusCodes.InternalServerError)
+    val retryTime2 = checkAndAnswerForwardedRequestWithTime(helper)
+
+    val delta = (retryTime2 - retryTime1).nanos
+    delta should be >= 500.millis
+    delta should be < 1000.millis
+  }
+
+  it should "retry only for the configured number of times with exponential backoff" in {
+    val RetryCount = 3
+    val backOffConfig = RetryExtension.BackoffConfig(minBackoff = 10.millis, maxBackoff = 25.millis)
+    val config = RetryExtension.RetryConfig(optMaxTimes = Some(RetryCount), optBackoff = Some(backOffConfig))
+    val helper = createHelper(config)
+
+    helper.sendTestRequest()
+    (1 to RetryCount).foreach { _ =>
+      helper.checkAndAnswerForwardedRequest {
+        failedResult(_, StatusCodes.BadGateway)
+      }
+    }
+    val result = helper.checkAndAnswerForwardedRequest {
+      failedResult(_, StatusCodes.BadRequest)
+    }.expectFailureResult()
+    result.cause match {
+      case e: FailedResponseException =>
+        e.response.status should be(StatusCodes.BadRequest)
+      case e => fail("Unexpected exception: " + e)
+    }
+  }
+
+  it should "handle a Stop command" in {
+    val helper = createHelper(RetryExtension.RetryConfig())
+
+    helper.checkHandlingOfStopMessage()
+  }
+}

--- a/core/src/test/scala/com/github/cloudfiles/core/http/RetryTestHelper.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/RetryTestHelper.scala
@@ -1,0 +1,160 @@
+package com.github.cloudfiles.core.http
+
+import com.github.cloudfiles.core.http.HttpRequestSender.{DiscardEntityMode, FailedResponseException}
+import com.github.cloudfiles.core.http.HttpRequestSender.DiscardEntityMode.DiscardEntityMode
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ActorTestKit, BehaviorTestKit}
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, HttpHeader, HttpRequest, HttpResponse, ResponseEntity, StatusCode}
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+object RetryTestHelper {
+  /** A test HTTP request sent to the test actor. */
+  final val TestRequest = HttpRequest(uri = "https://example.org/foo")
+
+  /** A data object associated with the test request. */
+  final val RequestData = "someRequestData"
+
+  /**
+   * A function alias for creating the behavior of an actor to be tested based
+   * on the passed in HTTP request sender actor.
+   */
+  type TestBehaviorCreator = ActorRef[HttpRequestSender.HttpCommand] => Behavior[HttpRequestSender.HttpCommand]
+
+  /**
+   * Creates a failed result object with a response that failed with the status
+   * code provided.
+   *
+   * @param request the request to be answered
+   * @param status  the status code
+   * @param headers headers of the response
+   * @param entity  an optional response entity
+   * @return the resulting ''FailedResult'' object
+   */
+  def failedResult(request: HttpRequestSender.SendRequest, status: StatusCode,
+                           headers: List[HttpHeader] = Nil, entity: ResponseEntity = HttpEntity.Empty):
+  HttpRequestSender.FailedResult =
+    HttpRequestSender.FailedResult(request,
+      FailedResponseException(HttpResponse(status = status, headers = headers, entity = entity)))
+}
+
+/**
+ * A test helper class for extension actors supporting a retry mechanism. The
+ * class provides functionality to send requests, generate responses, and check
+ * for results.
+ *
+ * @param testKit         the actor test kit
+ * @param matchers        the matchers for assertions
+ * @param behaviorCreator the function to create the behavior of the test actor
+ */
+class RetryTestHelper(testKit: ActorTestKit, matchers: Matchers)
+                     (behaviorCreator: RetryTestHelper.TestBehaviorCreator) {
+
+  import RetryTestHelper._
+  import matchers._
+
+  /** A probe acting as the underlying request actor. */
+  private val probeRequest = testKit.createTestProbe[HttpRequestSender.HttpCommand]()
+
+  /** A probe acting as the client of the request actor. */
+  private val probeReply = testKit.createTestProbe[HttpRequestSender.Result]()
+
+  /** The extension actor to be tested. */
+  private val retryExtension = testKit.spawn(behaviorCreator(probeRequest.ref))
+
+  /**
+   * Sends a test request to the test extension actor.
+   *
+   * @param discardMode the entity discard mode to set for this request
+   * @return this test helper
+   */
+  def sendTestRequest(discardMode: DiscardEntityMode = DiscardEntityMode.OnFailure): RetryTestHelper = {
+    val request = HttpRequestSender.SendRequest(TestRequest, RequestData, probeReply.ref, discardMode)
+    retryExtension ! request
+    this
+  }
+
+  /**
+   * Expects a forwarded request to be sent to the underlying request actor.
+   *
+   * @return the forwarded request
+   */
+  def expectForwardedRequest(): HttpRequestSender.SendRequest =
+    probeRequest.expectMessageType[HttpRequestSender.SendRequest]
+
+  /**
+   * Expects that a request is forwarded to the underlying request actor and
+   * sends a response.
+   *
+   * @param resultFunc a function to produce the result
+   * @tparam A the type of the result
+   * @return this test helper
+   */
+  def checkAndAnswerForwardedRequest[A <: HttpRequestSender.Result](resultFunc: HttpRequestSender.SendRequest => A):
+  RetryTestHelper = {
+    val fwdRequest = expectForwardedRequest()
+    fwdRequest.request should be(TestRequest)
+    val result = resultFunc(fwdRequest)
+    fwdRequest.replyTo ! result
+    this
+  }
+
+  /**
+   * Expects that a successful result is delivered to the client actor. Does
+   * some checks on the result.
+   *
+   * @return the result that was received
+   */
+  def expectSuccessResult(): HttpRequestSender.SuccessResult =
+    checkSendRequest(probeReply.expectMessageType[HttpRequestSender.SuccessResult])
+
+  /**
+   * Expects that a failure result is delivered to the client actor. Does
+   * some checks on the result.
+   *
+   * @return the result that was received
+   */
+  def expectFailureResult(): HttpRequestSender.FailedResult =
+    checkSendRequest(probeReply.expectMessageType[HttpRequestSender.FailedResult])
+
+  /**
+   * Checks that no message is forwarded to the underlying request actor in a
+   * specific time frame. This is used to test whether scheduling of retried
+   * requests works as expected.
+   *
+   * @return this test helper
+   */
+  def expectNoForwardedRequest(): RetryTestHelper = {
+    probeRequest.expectNoMessage(1500.millis)
+    this
+  }
+
+  /**
+   * Tests whether the actor under test correctly handles a ''Stop'' message by
+   * terminating itself and forwarding to the request sender actor.
+   */
+  def checkHandlingOfStopMessage(): Unit = {
+    val btk = BehaviorTestKit(behaviorCreator(probeRequest.ref))
+
+    btk.run(HttpRequestSender.Stop)
+    btk.returnedBehavior should be(Behaviors.stopped)
+    probeRequest.expectMessage(HttpRequestSender.Stop)
+  }
+
+  /**
+   * Checks whether the request contained in the given result has the
+   * expected properties of the test request.
+   *
+   * @param result the result to check
+   * @tparam A the type of the result
+   * @return the same result
+   */
+  private def checkSendRequest[A <: HttpRequestSender.Result](result: A): A = {
+    result.request.data should be(RequestData)
+    result.request.request should be(TestRequest)
+    result
+  }
+}
+

--- a/core/src/test/scala/com/github/cloudfiles/core/http/RetryTestHelper.scala
+++ b/core/src/test/scala/com/github/cloudfiles/core/http/RetryTestHelper.scala
@@ -34,7 +34,7 @@ object RetryTestHelper {
    * @return the resulting ''FailedResult'' object
    */
   def failedResult(request: HttpRequestSender.SendRequest, status: StatusCode,
-                           headers: List[HttpHeader] = Nil, entity: ResponseEntity = HttpEntity.Empty):
+                   headers: List[HttpHeader] = Nil, entity: ResponseEntity = HttpEntity.Empty):
   HttpRequestSender.FailedResult =
     HttpRequestSender.FailedResult(request,
       FailedResponseException(HttpResponse(status = status, headers = headers, entity = entity)))
@@ -65,16 +65,24 @@ class RetryTestHelper(testKit: ActorTestKit, matchers: Matchers)
   private val retryExtension = testKit.spawn(behaviorCreator(probeRequest.ref))
 
   /**
+   * Sends the given request to the actor to be tested.
+   *
+   * @param request the request to send
+   * @return this test helper
+   */
+  def sendRequest(request: HttpRequestSender.SendRequest): RetryTestHelper = {
+    retryExtension ! request
+    this
+  }
+
+  /**
    * Sends a test request to the test extension actor.
    *
    * @param discardMode the entity discard mode to set for this request
    * @return this test helper
    */
-  def sendTestRequest(discardMode: DiscardEntityMode = DiscardEntityMode.OnFailure): RetryTestHelper = {
-    val request = HttpRequestSender.SendRequest(TestRequest, RequestData, probeReply.ref, discardMode)
-    retryExtension ! request
-    this
-  }
+  def sendTestRequest(discardMode: DiscardEntityMode = DiscardEntityMode.OnFailure): RetryTestHelper =
+    sendRequest(HttpRequestSender.SendRequest(TestRequest, RequestData, probeReply.ref, discardMode))
 
   /**
    * Expects a forwarded request to be sent to the underlying request actor.


### PR DESCRIPTION
This PR adds another HTTP extension actor that implements a flexible retry mechanism for failed requests.